### PR TITLE
修正：unique Id 为空，和描述长度大于Windows最长文件名的情况

### DIFF
--- a/src/BlueCatKoKo.Ui/Services/DouYinShortVideoService.cs
+++ b/src/BlueCatKoKo.Ui/Services/DouYinShortVideoService.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Xml;
 using BlueCatKoKo.Ui.Constants;
 using BlueCatKoKo.Ui.Models;
 using Downloader;
@@ -108,7 +109,7 @@ public class DouYinShortVideoService : IShortVideoService
                 Platform = ShortVideoPlatformEnum.DouYin,
                 VideoId = videoInfoData.AwemeId,
                 AuthorName = videoInfoData.Author.Nickname,
-                UniqueId = videoInfoData.Author.UniqueId,
+                UniqueId = videoInfoData.Author.UniqueId==""?videoInfoData.Author.ShortId:videoInfoData.Author.UniqueId,
                 AuthorAvatar = videoInfoData.Author.AvatarThumb.UrlList.First().ToString(),
                 Title = videoInfoData.Author.Signature,
                 Cover = videoInfoData.Video.Cover.UrlList.Last().ToString(),

--- a/src/BlueCatKoKo.Ui/ViewModels/Pages/HomeViewModel.cs
+++ b/src/BlueCatKoKo.Ui/ViewModels/Pages/HomeViewModel.cs
@@ -177,7 +177,8 @@ namespace BlueCatKoKo.Ui.ViewModels.Pages
                 }
 
                 var filepath = _appConfig.Value.DownloadPath;
-                var filename = "#" + Data.AuthorName + "#" + Data.UniqueId + "# "+ Data.Desc + ".mp4";
+                var filename = "#" + Data.AuthorName + "#" + Data.UniqueId + "# " + Data.Desc;
+                filename = filename.Substring(0, Math.Min(250, ("#" + Data.AuthorName + "#" + Data.UniqueId + "# " + Data.Desc).Length))+".mp4";
 
                 var replaceFilename = filename.ReplaceInvalidCharacters();
 


### PR DESCRIPTION
修正潜在错误：
1. unique Id 为空
2. 描述长度大于Windows最长文件名